### PR TITLE
Remove transform property from after psuedo element in copyright icon

### DIFF
--- a/icons/copyright.css
+++ b/icons/copyright.css
@@ -17,5 +17,6 @@
     width: 8px;
     height: 8px;
     top: 3px;
-    left: 3px
+    left: 3px;
+    transform: none
 }


### PR DESCRIPTION
As there is scale being applied to both the `<i>` _and_ the pseudo element, it means that the scale applied to the psuedo element is being multiplied, so the C breaks out of the surrounding circle

Below is a screenshot taken from the https://css.gg/copyright page:

![image](https://user-images.githubusercontent.com/2059313/71131753-80f74d00-2245-11ea-8a54-75f47b2342bb.png)

As we can see, the C has well and truly broken out of it's surrounding boundary.

By simply applying `transform: none` to the `after` psuedo element specifically, the result is:

![image](https://user-images.githubusercontent.com/2059313/71131816-b3a14580-2245-11ea-918b-f6af5ebfd4bd.png)
