### PR TITLE
Add Penpot css.gg template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,10 @@ All icons are available as components on assets from where you can search for a 
 All icons are available as components \
 ![css.gg figma](https://css.gg/img/pxd.png)
 
+#### 3. Penpot - https://github.com/penpot/penpot-files/raw/main/cssgg-icons.penpot
+
+All icons are available as components. You can search for a single icon or browse categories.
+
 # Contributors
 
 1. [Astrit](https://github.com/astrit) - Author


### PR DESCRIPTION
Hey @astrit, thank you for this wonderful project!

I’ve created a css.gg icons library/template for [Penpot](https://github.com/penpot/penpot) users. 

The file is listed on the [Penpot Libraries & Templates collection](https://penpot.app/libraries-templates) and can be downloaded directly from the [GitHub file](https://github.com/penpot/penpot-files/raw/main/cssgg-icons.penpot). I have credited your work in both the file itself and in the [blog post I wrote about using icons from a shared library in Penpot](https://penpot.app/blog/tutorial-how-to-use-icons-from-a-shared-icon-library-in-penpot/).